### PR TITLE
fix docs for vue usage

### DIFF
--- a/docs/features/dataSaver.md
+++ b/docs/features/dataSaver.md
@@ -18,7 +18,7 @@ Also works in **Vue**:
 
 ```js
 <template>
-    <Image dataSaver src="someImageURL"/>
+    <Image data-saver src="someImageURL"/>
 </template>
 ```
 

--- a/docs/features/fetchOnDemand.md
+++ b/docs/features/fetchOnDemand.md
@@ -18,7 +18,7 @@ Also works in **Vue**:
 
 ```js
 <template>
-    <Image fetchOnDemand src="someImageURL"/>
+    <Image fetch-on-demand src="someImageURL"/>
 </template>
 ```
 

--- a/examples/vue/pages/index.vue
+++ b/examples/vue/pages/index.vue
@@ -8,11 +8,11 @@
 		</div>
 		<div class="item">
 			<h1>DataSaver Mode</h1>
-		<pimg dataSaver src="https://res.cloudinary.com/stackpie/image/upload/v1513979515/-895520106_m1whb3.jpg"/>
+		<pimg data-saver src="https://res.cloudinary.com/stackpie/image/upload/v1513979515/-895520106_m1whb3.jpg"/>
 		</div>
 		<div class="item">
 			<h1>FetchOnDemand Mode</h1>
-			<pimg fetchOnDemand src="https://res.cloudinary.com/stackpie/image/upload/v1513965940/1_znfymp.jpg"/>
+			<pimg fetch-on-demand src="https://res.cloudinary.com/stackpie/image/upload/v1513965940/1_znfymp.jpg"/>
 		</div>
 		</div>
 </template>


### PR DESCRIPTION
Currently, the docs don't work for Vue, as attributes should be in kebab-case in markup.