### PR TITLE
Handle placeholder generation

### DIFF
--- a/examples/preact/index.js
+++ b/examples/preact/index.js
@@ -43,12 +43,12 @@ const SimpleImplementation = () => (
 		<Image
 			className="myImage"
 			dataSaver
-			src="https://res.cloudinary.com/stackpie/image/upload/v1514275012/assassins_creed_revelations_concept_art-wallpaper-1366x768_qdl9vo.jpg"
+			src="https://res.cloudinary.com/dsevf03vj/image/upload/v1540223649/captain_america_the_winter_soldier_steve_rogers_chris_evans_captain_america_93014_1440x900_gwf6dh.jpg"
 		/>
 		{Editor(`<Image
 				className="myImage"
 				dataSaver
-				src="https://res.cloudinary.com/stackpie/image/upload/v1514275012/assassins_creed_revelations_concept_art-wallpaper-1366x768_qdl9vo.jpg"
+				src="https://res.cloudinary.com/dsevf03vj/image/upload/v1540223649/captain_america_the_winter_soldier_steve_rogers_chris_evans_captain_america_93014_1440x900_gwf6dh.jpg"
 		/>`)}
 	</Provider>
 )
@@ -57,13 +57,13 @@ const WithPlaceholder = () => (
 	<Provider title="Custom Placeholder">
 		<Image
 			className="myImage"
-			src="https://res.cloudinary.com/stackpie/image/upload/v1513979515/-895520106_m1whb3.jpg"
-			placeholder="https://res.cloudinary.com/stackpie/image/upload/c_thumb,w_10/v1513979515/-895520106_m1whb3.jpg"
+			src="https://res.cloudinary.com/dsevf03vj/image/upload/v1540223761/night_sky_snow-wallpaper-1440x900_b8bta9.jpg"
+			placeholder="https://res.cloudinary.com/dsevf03vj/image/upload/c_thumb,w_10/v1540223761/night_sky_snow-wallpaper-1440x900_b8bta9.jpg"
 		/>
 		{Editor(`<Image
 			className="myImage"
-			src="https://res.cloudinary.com/stackpie/image/upload/v1513979515/-895520106_m1whb3.jpg"
-			placeholder="https://res.cloudinary.com/stackpie/image/upload/c_thumb,w_10/v1513979515/-895520106_m1whb3.jpg"
+			src="https://res.cloudinary.com/dsevf03vj/image/upload/v1540223761/night_sky_snow-wallpaper-1440x900_b8bta9.jpg"
+			placeholder="https://res.cloudinary.com/dsevf03vj/image/upload/c_thumb,w_10/v1540223761/night_sky_snow-wallpaper-1440x900_b8bta9.jpg"
 		/>`)}
 	</Provider>
 )
@@ -75,14 +75,14 @@ const FetchOnDemand = () => (
 			fetchOnDemand
 			dataSaver
 			style={{ width: 200 }}
-			src="https://res.cloudinary.com/stackpie/image/upload/v1511099014/IMG_20161127_203939_073_nwdnvv.jpg"
+			src="https://res.cloudinary.com/dsevf03vj/image/upload/v1540223719/naruto_uzumaki_naruto_ninja_113276_1440x900_rwgddw.jpg"
 		/>
 		{Editor(`<Image
 			className="myImage"
 			fetchOnDemand
 			dataSaver
 			style={{ width: 200 }}
-			src="https://res.cloudinary.com/stackpie/image/upload/v1511099014/IMG_20161127_203939_073_nwdnvv.jpg"
+			src="https://res.cloudinary.com/dsevf03vj/image/upload/v1540223719/naruto_uzumaki_naruto_ninja_113276_1440x900_rwgddw.jpg"
 		/>`)}
 	</Provider>
 )
@@ -92,14 +92,12 @@ const FetchOnDemandWithPlaceholderProp = () => (
 		<Image
 			className="myImage"
 			fetchOnDemand
-			src="https://res.cloudinary.com/stackpie/image/upload/v1513965940/1_znfymp.jpg"
-			placeholder="https://res.cloudinary.com/stackpie/image/upload/c_thumb,w_10/v1513965940/1_znfymp.jpg"
+			src="https://res.cloudinary.com/dsevf03vj/image/upload/v1540223766/dark_earth-wallpaper-1440x900_se1quy.jpg"
 		/>
 		{Editor(`<Image
 			className="myImage"
 			fetchOnDemand
-			src="https://res.cloudinary.com/stackpie/image/upload/v1513965940/1_znfymp.jpg"
-			placeholder="https://res.cloudinary.com/stackpie/image/upload/c_thumb,w_10/v1513965940/1_znfymp.jpg"
+			src="https://res.cloudinary.com/dsevf03vj/image/upload/v1540223766/dark_earth-wallpaper-1440x900_se1quy.jpg"
 		/>`)}
 	</Provider>
 )

--- a/examples/react/index.js
+++ b/examples/react/index.js
@@ -53,12 +53,12 @@ const SimpleImplementation = () => (
 		<Image
 			className="myImage"
 			dataSaver
-			src="https://res.cloudinary.com/stackpie/image/upload/v1514275012/assassins_creed_revelations_concept_art-wallpaper-1366x768_qdl9vo.jpg"
+			src="https://res.cloudinary.com/dsevf03vj/image/upload/v1540223649/captain_america_the_winter_soldier_steve_rogers_chris_evans_captain_america_93014_1440x900_gwf6dh.jpg"
 		/>
 		{Editor(`<Image
 				className="myImage"
 				dataSaver
-				src="https://res.cloudinary.com/stackpie/image/upload/v1514275012/assassins_creed_revelations_concept_art-wallpaper-1366x768_qdl9vo.jpg"
+				src="https://res.cloudinary.com/dsevf03vj/image/upload/v1540223649/captain_america_the_winter_soldier_steve_rogers_chris_evans_captain_america_93014_1440x900_gwf6dh.jpg"
 		/>`)}
 	</Provider>
 )
@@ -67,13 +67,13 @@ const WithPlaceholder = () => (
 	<Provider title="Custom Placeholder">
 		<Image
 			className="myImage"
-			src="https://res.cloudinary.com/stackpie/image/upload/v1513979515/-895520106_m1whb3.jpg"
-			placeholder="https://res.cloudinary.com/stackpie/image/upload/c_thumb,w_10/v1513979515/-895520106_m1whb3.jpg"
+			src="https://res.cloudinary.com/dsevf03vj/image/upload/v1540223761/night_sky_snow-wallpaper-1440x900_b8bta9.jpg"
+			placeholder="https://res.cloudinary.com/dsevf03vj/image/upload/c_thumb,w_10/v1540223761/night_sky_snow-wallpaper-1440x900_b8bta9.jpg"
 		/>
 		{Editor(`<Image
 			className="myImage"
-			src="https://res.cloudinary.com/stackpie/image/upload/v1513979515/-895520106_m1whb3.jpg"
-			placeholder="https://res.cloudinary.com/stackpie/image/upload/c_thumb,w_10/v1513979515/-895520106_m1whb3.jpg"
+			src="https://res.cloudinary.com/dsevf03vj/image/upload/v1540223761/night_sky_snow-wallpaper-1440x900_b8bta9.jpg"
+			placeholder="https://res.cloudinary.com/dsevf03vj/image/upload/c_thumb,w_10/v1540223761/night_sky_snow-wallpaper-1440x900_b8bta9.jpg"
 		/>`)}
 	</Provider>
 )
@@ -85,14 +85,14 @@ const FetchOnDemand = () => (
 			fetchOnDemand
 			dataSaver
 			style={{ width: 200 }}
-			src="https://res.cloudinary.com/stackpie/image/upload/v1511099014/IMG_20161127_203939_073_nwdnvv.jpg"
+			src="https://res.cloudinary.com/dsevf03vj/image/upload/v1540223719/naruto_uzumaki_naruto_ninja_113276_1440x900_rwgddw.jpg"
 		/>
 		{Editor(`<Image
 			className="myImage"
 			fetchOnDemand
 			dataSaver
 			style={{ width: 200 }}
-			src="https://res.cloudinary.com/stackpie/image/upload/v1511099014/IMG_20161127_203939_073_nwdnvv.jpg"
+			src="https://res.cloudinary.com/dsevf03vj/image/upload/v1540223719/naruto_uzumaki_naruto_ninja_113276_1440x900_rwgddw.jpg"
 		/>`)}
 	</Provider>
 )
@@ -102,14 +102,12 @@ const FetchOnDemandWithPlaceholderProp = () => (
 		<Image
 			className="myImage"
 			fetchOnDemand
-			src="https://res.cloudinary.com/stackpie/image/upload/v1513965940/1_znfymp.jpg"
-			placeholder="https://res.cloudinary.com/stackpie/image/upload/c_thumb,w_10/v1513965940/1_znfymp.jpg"
+			src="https://res.cloudinary.com/dsevf03vj/image/upload/v1540223766/dark_earth-wallpaper-1440x900_se1quy.jpg"
 		/>
 		{Editor(`<Image
 			className="myImage"
 			fetchOnDemand
-			src="https://res.cloudinary.com/stackpie/image/upload/v1513965940/1_znfymp.jpg"
-			placeholder="https://res.cloudinary.com/stackpie/image/upload/c_thumb,w_10/v1513965940/1_znfymp.jpg"
+			src="https://res.cloudinary.com/dsevf03vj/image/upload/v1540223766/dark_earth-wallpaper-1440x900_se1quy.jpg"
 		/>`)}
 	</Provider>
 )


### PR DESCRIPTION
### What does this PR do?
Fixes a bug where a placeholder is being generated for wrong `src` assumed to be a Cloudinary image.

#### How to test this PR?
```javascript
/*
* Before
* Given an image with src other than Cloudinary
* https://cdn.pexels.com/upload/2012/02/10/cloudinary__340.jpg
*/
if (src && src.includes('cloudinary')) { // matches
  ...
}
```
As stated in Cloudinary documentation [here](https://cloudinary.com/documentation/solution_overview#urls_and_endpoints), the best way to test if the image is from Cloudinary is to check in the host

```javascript
/*
* After
* Given an image with src other than Cloudinary
* https://cdn.pexels.com/upload/2012/02/10/cloudinary__340.jpg
*/
try {
  const srcURL = new URL(src)
  if (srcURL.host.includes('cloudinary')) { // does not match
    ...
  }
} catch(err) {}
```