### PR TITLE
add comment to intersectionObserver docs re: placeholders

### DIFF
--- a/docs/intersectionObserver.md
+++ b/docs/intersectionObserver.md
@@ -21,5 +21,4 @@ let observer = new IntersectionObserver(entries => {
 observer.observe(this.image())
 ```
 
-
-
+It's worth pointing out that, unless your CSS specifies otherwise, the placeholder elements will be zero height. It's recommended that you make the dimensions of the placeholder as close as you can to the image being loaded via CSS and the `placeholderClassName` setting (default is `.pimg__placeholder`.)


### PR DESCRIPTION
Just a simple addition to the docs. If I get a chance, I'll see if I can add a feature for passing in a height or aspect ratio or such.

I think this is worth mentioning, as when I saw this behavior, I thought it was a bug where only the top edge of the image was triggering events.