### PR TITLE
[fix] Warning on component receive props

### DIFF
--- a/src/preact/index.js
+++ b/src/preact/index.js
@@ -154,6 +154,7 @@ class Image extends Component {
 			<img
 				className={className ? className : getClassName()}
 				src={blob}
+				ref={i => (this.imgElement = i)}
 				{...rest}
 			/>
 		)


### PR DESCRIPTION
When component receive new props / re-render, warning 'fetchOnDemand not supported on this browser' is appeared in console.